### PR TITLE
Ignore eslint version 9.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,6 @@ updates:
     groups:
       dependencies:
         patterns: ["*"]
+    ignore:
+      - dependency-name: "eslint"
+        versions: ["9.x"]


### PR DESCRIPTION
Dealing with Dependency Errors : 
    Bump eslint from 8.57.0 to 9.7.0 in the dependencies group
